### PR TITLE
Nav improvements and integration

### DIFF
--- a/code/css/forms.css
+++ b/code/css/forms.css
@@ -108,13 +108,3 @@ input[type="file"]::file-selector-button {
 input[type="file"]::file-selector-button:hover {
 	background-color: var(--background-primary);
 }
-
-/* TODO: remove i think */
-/* @media (max-width: 768px) {
-	.account-form {
-		box-shadow: none;
-		border-radius: 0;
-		width: 100%;
-		height: 100vh;
-	}
-} */

--- a/code/css/forms.css
+++ b/code/css/forms.css
@@ -1,9 +1,10 @@
 .form-container {
-	/* min-height: 100vh; */
+    padding: 1em;
+    height: 100%;
+    box-sizing: border-box;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	overflow: auto;
 }
 
 .account-form {

--- a/code/css/forms.css
+++ b/code/css/forms.css
@@ -1,5 +1,5 @@
-main {
-	min-height: 100vh;
+.form-container {
+	/* min-height: 100vh; */
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/code/css/forms.css
+++ b/code/css/forms.css
@@ -10,7 +10,6 @@
 .account-form {
 	display: flex;
 	flex-direction: column;
-	overflow: auto;
 	align-items: center;
 	background-color: var(--background-secondary);
 	border-radius: 0.5em;
@@ -110,11 +109,12 @@ input[type="file"]::file-selector-button:hover {
 	background-color: var(--background-primary);
 }
 
-@media (max-width: 768px) {
+/* TODO: remove i think */
+/* @media (max-width: 768px) {
 	.account-form {
 		box-shadow: none;
 		border-radius: 0;
 		width: 100%;
 		height: 100vh;
 	}
-}
+} */

--- a/code/css/main.css
+++ b/code/css/main.css
@@ -36,8 +36,9 @@ body {
     grid-template-columns: auto 1fr;
 }
 header {
-    grid-column: 1;
+    grid-column-start: 1;
 }
 main {
-    grid-column: 2;
+    grid-column-start: 2;
+    min-height: 100vh;
 }

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -38,6 +38,10 @@ Styles for the side navigation bar.
     background-color: var(--accent-hover);
 }
 
+.nav-link.collapsed .link-text {
+    display: none;
+}
+
 .nav-link.current-page {
     background-color: var(--background-primary);
     color: var(--accent-primary);

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -26,7 +26,7 @@ Styles for the side navigation bar.
 }
 #side-nav:hover{
     overflow-y: auto;
-    scrollbar-width: thin;
+    scrollbar-color: var(--background-primary) var(--accent-hover);
 }
 
 #logo-container {

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -18,16 +18,11 @@ Styles for the side navigation bar.
     position: sticky;
     top: 0;
     left: 0;
-    overflow-y: hidden;
-    scrollbar-gutter: auto;
+    overflow-y: auto;
 
     display: grid;
     grid-template-rows: auto auto auto 1fr auto;
     gap: 1em;
-}
-#side-nav:hover{
-    overflow-y: auto;
-    scrollbar-color: var(--background-primary) var(--accent-primary);
 }
 
 #logo-container {

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -3,7 +3,7 @@
 Styles for the side navigation bar.
 */
 
-/* SIDE NAV and its GRID CELLS */
+/* SIDE NAV */
 #side-nav {
     color: var(--text-secondary);
     background-color: var(--accent-primary);
@@ -11,12 +11,40 @@ Styles for the side navigation bar.
     width:fit-content;
     height: 100%;
     min-height: 100vh;
+    max-height: 100vh;
     padding: 0 0 1em;
     box-sizing: border-box;
+
+    position: fixed;
+    top: 0;
+    left: 0;
+    overflow-y: auto;
 
     display: grid;
     grid-template-rows: auto auto auto 1fr auto;
     gap: 1em;
+}
+/* Scrollbar stuff */
+/* .side-nav::-webkit-scrollbar {
+    width: 0;
+}
+.side-nav:hover::-webkit-scrollbar {
+    width: auto;
+} */
+
+/* Optional: Style the scrollbar thumb */
+/* .side-nav::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2);
+    border-radius: 4px;
+} */
+
+/* Hide scrollbar by default (Firefox) */
+/* .side-nav{
+    scrollbar-width: none;
+} */
+/* show scrollbar on hover (Firefox) by removing the scrollbar-width property */
+/* .side-nav:hover{
+    scrollbar-width: auto;
 }
 
 #logo-container {
@@ -25,7 +53,7 @@ Styles for the side navigation bar.
 
 #bottom-links {
     align-self: self-end;
-}
+} */
 
 /* LINKS */
 /* Normal */

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -15,10 +15,11 @@ Styles for the side navigation bar.
     padding: 0 0 1em;
     box-sizing: border-box;
 
-    position: fixed;
+    position: sticky;
     top: 0;
     left: 0;
     overflow-y: hidden;
+    scrollbar-gutter: auto;
 
     display: grid;
     grid-template-rows: auto auto auto 1fr auto;
@@ -26,7 +27,7 @@ Styles for the side navigation bar.
 }
 #side-nav:hover{
     overflow-y: auto;
-    scrollbar-color: var(--background-primary) var(--accent-hover);
+    scrollbar-color: var(--background-primary) var(--accent-primary);
 }
 
 #logo-container {

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -18,33 +18,15 @@ Styles for the side navigation bar.
     position: fixed;
     top: 0;
     left: 0;
-    overflow-y: auto;
+    overflow-y: hidden;
 
     display: grid;
     grid-template-rows: auto auto auto 1fr auto;
     gap: 1em;
 }
-/* Scrollbar stuff */
-/* .side-nav::-webkit-scrollbar {
-    width: 0;
-}
-.side-nav:hover::-webkit-scrollbar {
-    width: auto;
-} */
-
-/* Optional: Style the scrollbar thumb */
-/* .side-nav::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 4px;
-} */
-
-/* Hide scrollbar by default (Firefox) */
-/* .side-nav{
-    scrollbar-width: none;
-} */
-/* show scrollbar on hover (Firefox) by removing the scrollbar-width property */
-/* .side-nav:hover{
-    scrollbar-width: auto;
+#side-nav:hover{
+    overflow-y: auto;
+    scrollbar-width: thin;
 }
 
 #logo-container {
@@ -53,7 +35,7 @@ Styles for the side navigation bar.
 
 #bottom-links {
     align-self: self-end;
-} */
+}
 
 /* LINKS */
 /* Normal */

--- a/code/css/side-nav.css
+++ b/code/css/side-nav.css
@@ -28,6 +28,7 @@ Styles for the side navigation bar.
 }
 
 /* LINKS */
+/* Normal */
 .nav-link {
     color: inherit;
     display: block;
@@ -38,10 +39,7 @@ Styles for the side navigation bar.
     background-color: var(--accent-hover);
 }
 
-.nav-link.collapsed .link-text {
-    display: none;
-}
-
+/* Current page highlight */
 .nav-link.current-page {
     background-color: var(--background-primary);
     color: var(--accent-primary);
@@ -50,6 +48,7 @@ Styles for the side navigation bar.
     fill: var(--accent-primary);
 }
 
+/* No access for login state reasons */
 .nav-link.no-access {
     color: var(--accent-dark);
 }
@@ -63,7 +62,7 @@ Styles for the side navigation bar.
     background-color: var(--accent-hover);
     height:fit-content;
     margin: 0 0.75em;
-    padding: 0.2em 1em;
+    padding: 0.2em 0.1em;
     border: none;
     border-radius:4em;
     font-weight: bold;
@@ -87,4 +86,26 @@ Styles for the side navigation bar.
     width: 4em;
     height: 4em;
     margin: 1em auto 0.75em;
+}
+
+/* COLLAPSED NAVBAR STATE */
+/* Collapsed navbar */
+.collapsed {
+    text-align: center;
+    /* padding: 0.3em; */
+}
+.collapsed .icon {
+    margin-right: 0em;
+}
+.collapsed .link-text {
+    display: none;
+}
+.collapsed:has(.icon-logo) {
+    padding: 0em;
+}
+.collapsed .icon-logo {
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: auto;
+    margin-left: auto;
 }

--- a/code/html/side-nav.html
+++ b/code/html/side-nav.html
@@ -56,5 +56,5 @@ Main navigation component. Include it in a <header> tag at the start of the body
     </a>
   </div>
 
-  <button id="nav-collapse-button" class="button-collapse" title="Collapse Menu"><</button>
+  <button id="nav-collapse-button" class="button-collapse" title="Collapse Navigation"><</button>
 </nav>

--- a/code/html/side-nav.html
+++ b/code/html/side-nav.html
@@ -5,7 +5,7 @@ Main navigation component. Include it in a <header> tag at the start of the body
 
 <nav id="side-nav">
   <div id="logo-container">
-    <a class="nav-link" href=home.php>
+    <a id="nav-logo" class="nav-link" href="home.php">
       <svg class="icon icon-logo" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-logo"></use></svg>
       OUR SITE
     </a>

--- a/code/html/side-nav.html
+++ b/code/html/side-nav.html
@@ -7,54 +7,54 @@ Main navigation component. Include it in a <header> tag at the start of the body
   <div id="logo-container">
     <a id="nav-logo" class="nav-link" href="home.php">
       <svg class="icon icon-logo" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-logo"></use></svg>
-      OUR SITE
+      <span class="link-text">OUR SITE</span>
     </a>
   </div>
 
   <div id="top-links">
     <a class="nav-link" href="home.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-home"></use></svg>
-      Home
+      <span class="link-text">Home</span>
     </a>
     <a class="nav-link no-access" href="profile.php"> <!-- TODO: remove no-access example once its dynamic -->
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-profile"></use></svg>
-      Profile
+      <span class="link-text">Profile</span>
     </a>
     <a class="nav-link" href="create_post.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-create"></use></svg>
-      Create
+      <span class="link-text">Create</span>
     </a>
     <a class="nav-link" href="search.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-search"></use></svg>
-      Search
+      <span class="link-text">Search</span>
     </a>
   </div>
 
   <div id="middle-links">
     <a class="nav-link" href="admin.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-admin"></use></svg>
-      Admin
+      <span class="link-text">Admin</span>
     </a>
   </div>
 
   <div id="bottom-links">
     <a class="nav-link" href="login.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-login"></use></svg>
-      Login
+      <span class="link-text">Login</span>
     </a>
-    <a class="nav-link current-page" href="register.php"> <!-- TODO: remove current-page example once its dynamic -->
+    <a class="nav-link" href="register.php"> <!-- TODO: remove current-page example once its dynamic -->
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-register"></use></svg>
-      Register
+      <span class="link-text">Register</span>
     </a>
     <a class="nav-link" href="logout.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-logout"></use></svg>
-      Logout
+      <span class="link-text">Logout</span>
     </a>
     <a class="nav-link" href="about.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-about"></use></svg>
-      About
+      <span class="link-text">About</span>
     </a>
   </div>
 
-  <button class="button-collapse" title="Collapse Menu"><</button>
+  <button id="nav-collapse-button" class="button-collapse" title="Collapse Menu"><</button>
 </nav>

--- a/code/html/side-nav.html
+++ b/code/html/side-nav.html
@@ -42,7 +42,7 @@ Main navigation component. Include it in a <header> tag at the start of the body
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-login"></use></svg>
       <span class="link-text">Login</span>
     </a>
-    <a class="nav-link" href="register.php"> <!-- TODO: remove current-page example once its dynamic -->
+    <a class="nav-link" href="register.php">
       <svg class="icon" preserveAspectRatio="xMidYMid meet"><use href="../icons/icons.svg#icon-register"></use></svg>
       <span class="link-text">Register</span>
     </a>

--- a/code/pages/about.php
+++ b/code/pages/about.php
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/main.css">
   <link rel="stylesheet" href="../css/side-nav.css">
+  <script src="../scripts/side-nav.js"></script>
 </head>
 
 <body>

--- a/code/pages/about.php
+++ b/code/pages/about.php
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/main.css">
   <link rel="stylesheet" href="../css/side-nav.css">
-  <script src="../scripts/side-nav.js"></script>
+  <script src="../scripts/side-nav.js" defer></script>
 </head>
 
 <body>

--- a/code/pages/about.php
+++ b/code/pages/about.php
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
 
   <title>
-    Our Site | About
+    About | Our Site
   </title>
 
   <link rel="stylesheet" href="../css/reset.css">

--- a/code/pages/home.php
+++ b/code/pages/home.php
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/main.css">
   <link rel="stylesheet" href="../css/side-nav.css">
+  <script src="../scripts/side-nav.js"></script>
 </head>
 
 <body>

--- a/code/pages/home.php
+++ b/code/pages/home.php
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
 
   <title>
-    Our Site | Home
+    Home | Our Site
   </title>
 
   <link rel="stylesheet" href="../css/reset.css">

--- a/code/pages/home.php
+++ b/code/pages/home.php
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="../css/reset.css">
   <link rel="stylesheet" href="../css/main.css">
   <link rel="stylesheet" href="../css/side-nav.css">
-  <script src="../scripts/side-nav.js"></script>
+  <script src="../scripts/side-nav.js" defer></script>
 </head>
 
 <body>

--- a/code/pages/login.php
+++ b/code/pages/login.php
@@ -17,23 +17,25 @@
     <?php include "../html/side-nav.html" ?>
   </header>
   <main>
-    <form id="login-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
-      <h2 class="form-title">Log in to your account</h2>
-      <div class="form-group">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email"
-          required />
-      </div>
-      <div class="form-group">
-        <span>
-          <label for="password">Password</label>
-          <a href="">Forgot password?</a> <!-- TODO: Password reset page (low priority) -->
-        </span>
-        <input type="password" id="password" name="password" placeholder="Enter your password" required />
-      </div>
-      <button type="submit">Log in</button>
-      <p>Don't have an account? <a href="register.html">Register an account</a></p>
-    </form>
+    <div class="form-container">
+      <form id="login-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
+        <h2 class="form-title">Log in to your account</h2>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email"
+            required />
+        </div>
+        <div class="form-group">
+          <span>
+            <label for="password">Password</label>
+            <a href="">Forgot password?</a> <!-- TODO: Password reset page (low priority) -->
+          </span>
+          <input type="password" id="password" name="password" placeholder="Enter your password" required />
+        </div>
+        <button type="submit">Log in</button>
+        <p>Don't have an account? <a href="register.html">Register an account</a></p>
+      </form>
+    </div>
   </main>
 </body>
 

--- a/code/pages/login.php
+++ b/code/pages/login.php
@@ -33,7 +33,7 @@
           <input type="password" id="password" name="password" placeholder="Enter your password" required />
         </div>
         <button type="submit">Log in</button>
-        <p>Don't have an account? <a href="register.html">Register an account</a></p>
+        <p>Don't have an account? <a href="register.php">Register an account</a></p>
       </form>
     </div>
   </main>

--- a/code/pages/login.php
+++ b/code/pages/login.php
@@ -8,10 +8,14 @@
   <link rel="stylesheet" href="../css/reset.css" />
   <link rel="stylesheet" href="../css/main.css" />
   <link rel="stylesheet" href="../css/forms.css" />
+  <link rel="stylesheet" href="../css/side-nav.css">
+  <script src="../scripts/side-nav.js" defer></script>
 </head>
 
 <body>
-  <nav></nav> <!-- TODO: Import sidenav -->
+  <header>
+    <?php include "../html/side-nav.html" ?>
+  </header>
   <main>
     <form id="login-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
       <h2 class="form-title">Log in to your account</h2>

--- a/code/pages/login.php
+++ b/code/pages/login.php
@@ -19,7 +19,7 @@
   <main>
     <div class="form-container">
       <form id="login-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
-        <h2 class="form-title">Log in to your account</h2>
+        <h1 class="form-title">Log in to your account</h1>
         <div class="form-group">
           <label for="email">Email</label>
           <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email"

--- a/code/pages/register.php
+++ b/code/pages/register.php
@@ -41,7 +41,7 @@
           <input type="file" id="profile-picture" name="profile-picture" required />
         </div>
         <button type="submit">Register</button>
-        <p>Already have an account? <a href="login.html">Log in</a></p>
+        <p>Already have an account? <a href="login.php">Log in</a></p>
       </form>
     </div>
   </main>

--- a/code/pages/register.php
+++ b/code/pages/register.php
@@ -19,7 +19,7 @@
   <main>
     <div class="form-container">
       <form id="registration-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
-        <h2 class="form-title">Register for an account</h2>
+        <h1 class="form-title">Register for an account</h1>
         <div class="form-group">
           <label for="user-id">User id</label>
           <input type="text" id="user-id" name="user-id" placeholder="Enter your user id" required />

--- a/code/pages/register.php
+++ b/code/pages/register.php
@@ -17,31 +17,33 @@
     <?php include "../html/side-nav.html" ?>
   </header>
   <main>
-    <form id="registration-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
-      <h2 class="form-title">Register for an account</h2>
-      <div class="form-group">
-        <label for="user-id">User id</label>
-        <input type="text" id="user-id" name="user-id" placeholder="Enter your user id" required />
-      </div>
-      <div class="form-group">
-        <label for="email">Email</label>
-        <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email" required />
-      </div>
-      <div class="form-group">
-        <label for="password">Password</label>
-        <input type="password" id="password" name="password" placeholder="Enter your password" required />
-      </div>
-      <div class="form-group">
-        <label for="confirm-password">Confirm password</label>
-        <input type="password" id="confirm-password" name="confirm-password" placeholder="Re-enter your password" required />
-      </div>
-      <div class="form-group">
-        <label for="profile-picture">Upload profile picture</label>
-        <input type="file" id="profile-picture" name="profile-picture" required />
-      </div>
-      <button type="submit">Register</button>
-      <p>Already have an account? <a href="login.html">Log in</a></p>
-    </form>
+    <div class="form-container">
+      <form id="registration-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
+        <h2 class="form-title">Register for an account</h2>
+        <div class="form-group">
+          <label for="user-id">User id</label>
+          <input type="text" id="user-id" name="user-id" placeholder="Enter your user id" required />
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email" required />
+        </div>
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input type="password" id="password" name="password" placeholder="Enter your password" required />
+        </div>
+        <div class="form-group">
+          <label for="confirm-password">Confirm password</label>
+          <input type="password" id="confirm-password" name="confirm-password" placeholder="Re-enter your password" required />
+        </div>
+        <div class="form-group">
+          <label for="profile-picture">Upload profile picture</label>
+          <input type="file" id="profile-picture" name="profile-picture" required />
+        </div>
+        <button type="submit">Register</button>
+        <p>Already have an account? <a href="login.html">Log in</a></p>
+      </form>
+    </div>
   </main>
 </body>
 

--- a/code/pages/register.php
+++ b/code/pages/register.php
@@ -8,10 +8,14 @@
   <link rel="stylesheet" href="../css/reset.css" />
   <link rel="stylesheet" href="../css/main.css" />
   <link rel="stylesheet" href="../css/forms.css" />
+  <link rel="stylesheet" href="../css/side-nav.css">
+  <script src="../scripts/side-nav.js" defer></script>
 </head>
 
 <body>
-  <nav></nav> <!-- TODO: Import sidenav -->
+  <header>
+    <?php include "../html/side-nav.html" ?>
+  </header>
   <main>
     <form id="registration-form" class="account-form" method="post" novalidate> <!-- TODO: Set up form action -->
       <h2 class="form-title">Register for an account</h2>

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -7,6 +7,16 @@ Performs the following dynamic actions:
 
 document.addEventListener("DOMContentLoaded", () => {
 
-    
+    const navLinks = document.querySelectorAll(".nav-link");
 
+    for (navLink of navLinks) {
+        if (navLink.href  === window.location.href
+            && navLink.id != "nav-logo")
+        {
+            navLink.classList.add("current-page");
+        }
+        else if (navLink.classList.contains("current-page")) {
+            navLink.classList.remove("current-page");
+        }
+    }
 });

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -1,0 +1,12 @@
+/* side-nav.js
+--------------------------------------
+Performs the following dynamic actions:
+- highlighting link of current page
+- collapsing and expanding the navbar on button press
+-------------------------------------- */
+
+document.addEventListener("DOMContentLoaded", () => {
+
+    
+
+});

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -5,49 +5,46 @@ Performs the following dynamic actions:
 - collapsing and expanding the navbar on button press
 -------------------------------------- */
 
-document.addEventListener("DOMContentLoaded", () => {
+// HIGHLIGHT NAVLINK OF CURRENT PAGE
+// ---------------------------------
+const navLinks = document.querySelectorAll(".nav-link");
 
-    // HIGHLIGHT NAVLINK OF CURRENT PAGE
-    // ---------------------------------
-    const navLinks = document.querySelectorAll(".nav-link");
-
-    for (navLink of navLinks) {
-        if ((navLink.href  === window.location.href) && (navLink.id != "nav-logo")) {
-            navLink.classList.add("current-page");
-        }
+for (navLink of navLinks) {
+    if ((navLink.href  === window.location.href) && (navLink.id != "nav-logo")) {
+        navLink.classList.add("current-page");
     }
+}
 
-    // COLLAPSE/EXPAND NAV
-    // -------------------
-    const navCollapseButton = document.getElementById("nav-collapse-button");
+// COLLAPSE/EXPAND NAV
+// -------------------
+const navCollapseButton = document.getElementById("nav-collapse-button");
 
-    navCollapseButton.addEventListener("click", () => {
-        if(sessionStorage.getItem("navCollapsed")) {
-            expandNav();
-        }
-        else{
-            collapseNav();
-        }
-    });
-
-    function collapseNav() {
-        for (navLink of navLinks) {
-            navLink.classList.add("collapsed");
-        }
-        navCollapseButton.textContent = ">";
-        navCollapseButton.title = "Expand Navigation";
-        sessionStorage.setItem("navCollapsed", "true");
+navCollapseButton.addEventListener("click", () => {
+    if(sessionStorage.getItem("navCollapsed")) {
+        expandNav();
     }
-
-    function expandNav() {
-        for (navLink of navLinks) {
-            navLink.classList.remove("collapsed");
-        }
-        navCollapseButton.textContent = "<";
-        navCollapseButton.title = "Collapse Navigation";
-        sessionStorage.removeItem("navCollapsed");
+    else{
+        collapseNav();
     }
 });
+
+function collapseNav() {
+    for (navLink of navLinks) {
+        navLink.classList.add("collapsed");
+    }
+    navCollapseButton.textContent = ">";
+    navCollapseButton.title = "Expand Navigation";
+    sessionStorage.setItem("navCollapsed", "true");
+}
+
+function expandNav() {
+    for (navLink of navLinks) {
+        navLink.classList.remove("collapsed");
+    }
+    navCollapseButton.textContent = "<";
+    navCollapseButton.title = "Collapse Navigation";
+    sessionStorage.removeItem("navCollapsed");
+}
 
 // TODO: make the navbar collapse remember its state when you go to a new page
 // window.addEventListener("DOMContentLoaded")

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -7,16 +7,29 @@ Performs the following dynamic actions:
 
 document.addEventListener("DOMContentLoaded", () => {
 
+    // HIGHLIGHT NAVLINK OF CURRENT PAGE
+    // ---------------------------------
     const navLinks = document.querySelectorAll(".nav-link");
 
     for (navLink of navLinks) {
-        if (navLink.href  === window.location.href
-            && navLink.id != "nav-logo")
-        {
+        if ((navLink.href  === window.location.href) && (navLink.id != "nav-logo")) {
             navLink.classList.add("current-page");
         }
-        else if (navLink.classList.contains("current-page")) {
-            navLink.classList.remove("current-page");
-        }
     }
+
+    // COLLAPSE/EXPAND NAV
+    // -------------------
+    // const navCollapseButton = document.getElementById("nav-collapse-button");
+
+    // navCollapseButton.addEventListener("onClick", () => {
+    //     console.log('button clicked');
+    //     // get all links
+    //     for (navLink of navLinks) {
+            
+    //     }
+    //     // toggle hide text from links (might have to surround them all in spans for this)
+    //     // toggle class: change collapse logo size
+    //     // toggle class: remove padding extra right padding from icons?
+    //     // swap arrow direction of button content
+    // });
 });

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -22,19 +22,32 @@ document.addEventListener("DOMContentLoaded", () => {
     const navCollapseButton = document.getElementById("nav-collapse-button");
 
     navCollapseButton.addEventListener("click", () => {
-
-        for (navLink of navLinks) {
-            navLink.classList.toggle("collapsed");
+        if(sessionStorage.getItem("navCollapsed")) {
+            expandNav();
         }
-
-        // swap arrow direction and change tooltip
-        if (navCollapseButton.textContent === "<") {
-            navCollapseButton.textContent = ">";
-            navCollapseButton.title = "Expand Navigation";
-        }
-        else {
-            navCollapseButton.textContent = "<";
-            navCollapseButton.title = "Collapse Navigation";
+        else{
+            collapseNav();
         }
     });
+
+    function collapseNav() {
+        for (navLink of navLinks) {
+            navLink.classList.add("collapsed");
+        }
+        navCollapseButton.textContent = ">";
+        navCollapseButton.title = "Expand Navigation";
+        sessionStorage.setItem("navCollapsed", "true");
+    }
+
+    function expandNav() {
+        for (navLink of navLinks) {
+            navLink.classList.remove("collapsed");
+        }
+        navCollapseButton.textContent = "<";
+        navCollapseButton.title = "Collapse Navigation";
+        sessionStorage.removeItem("navCollapsed");
+    }
 });
+
+// TODO: make the navbar collapse remember its state when you go to a new page
+// window.addEventListener("DOMContentLoaded")

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -19,6 +19,16 @@ for (navLink of navLinks) {
 // -------------------
 const navCollapseButton = document.getElementById("nav-collapse-button");
 
+// SET CORRECT COLLAPSE STATE
+// (maintains same state as previous page)
+if(sessionStorage.getItem("navCollapsed")) {
+    collapseNav();
+}
+else{
+    expandNav();
+}
+
+// CONFIGURE BUTTON
 navCollapseButton.addEventListener("click", () => {
     if(sessionStorage.getItem("navCollapsed")) {
         expandNav();
@@ -28,6 +38,7 @@ navCollapseButton.addEventListener("click", () => {
     }
 });
 
+// HELPER FUNCTIONS
 function collapseNav() {
     for (navLink of navLinks) {
         navLink.classList.add("collapsed");
@@ -45,6 +56,4 @@ function expandNav() {
     navCollapseButton.title = "Collapse Navigation";
     sessionStorage.removeItem("navCollapsed");
 }
-
-// TODO: make the navbar collapse remember its state when you go to a new page
-// window.addEventListener("DOMContentLoaded")
+// ---------------------------------------------------------

--- a/code/scripts/side-nav.js
+++ b/code/scripts/side-nav.js
@@ -19,17 +19,22 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // COLLAPSE/EXPAND NAV
     // -------------------
-    // const navCollapseButton = document.getElementById("nav-collapse-button");
+    const navCollapseButton = document.getElementById("nav-collapse-button");
 
-    // navCollapseButton.addEventListener("onClick", () => {
-    //     console.log('button clicked');
-    //     // get all links
-    //     for (navLink of navLinks) {
-            
-    //     }
-    //     // toggle hide text from links (might have to surround them all in spans for this)
-    //     // toggle class: change collapse logo size
-    //     // toggle class: remove padding extra right padding from icons?
-    //     // swap arrow direction of button content
-    // });
+    navCollapseButton.addEventListener("click", () => {
+
+        for (navLink of navLinks) {
+            navLink.classList.toggle("collapsed");
+        }
+
+        // swap arrow direction and change tooltip
+        if (navCollapseButton.textContent === "<") {
+            navCollapseButton.textContent = ">";
+            navCollapseButton.title = "Expand Navigation";
+        }
+        else {
+            navCollapseButton.textContent = "<";
+            navCollapseButton.title = "Collapse Navigation";
+        }
+    });
 });


### PR DESCRIPTION
# Changes
## Dynamic Nav Stuff
### `side-nav.js`
- highlights navlink of current page
- allows nav to collapse and expand (and remembers collapse state from previous page)

### General nav improvements:
- it is sticky now
- nav-specific scrollbar shows up at high zoom levels to allow user to navigate it. This technique is used by many sites, e.g. YouTube, Canvas.
  - I messed around with special appearances/behaviour for the scrollbar for a while, including having it only show up on hover, but in the end it got to complicated and I reverted back to the default behaviour

## Login/Register Integration
- they now include the side nav
- Headings changed to `h1` tag as discussed in Discord
- New container element `.form-container`.
  - `<main>` is now reserved for the layout styling in `main.css`, so I moved the styles previously applied to it to `.form-container` and tweaked them.
  - added padding
- removed in-form scrolling, better to just scroll the whole page imo

> [!NOTE]
> I think we should remove the media query declaration block in `forms.css`. Right now it causes problems with content overflow at high zoom levels. Without it, the login/register pages still look fine at pretty much all zoom levels (horizontal scrollbar only shows up at very high zoom levels or very narrow window sizes), and it still works on mobile, especially with a collapsed nav (even though _home_ and _about_ pages don't lol).
>  - I've commented it out for now so you can mess around with it if you want to. If you agree with me, please remove it.