### PR TITLE
Registration form fixes

### DIFF
--- a/code/app/controllers/UserController.php
+++ b/code/app/controllers/UserController.php
@@ -25,17 +25,27 @@ class UserController {
             require __DIR__.'/../views/register-view.php';
         }
         else {
-            $this->userModel->createUser([
-                'username'  => $_POST['username'],
-                'email'     => $_POST['email'],
-                'password'  => $_POST['password'],
-                'image'     => $_FILES['profile-picture'],
-                'bio'       => 'This user has not added a bio yet.'
-            ]);
-    
-            //redirect to another page
-            header('Location: /login');
-            exit;
+            $username = $_POST['username'];
+            $email = $_POST['email'];
+            $userExists = $this->userModel->checkUserExists($username, $email);
+
+            if (!$userExists) {
+                $this->userModel->createUser([
+                    'username'  => $_POST['username'],
+                    'email'     => $_POST['email'],
+                    'password'  => $_POST['password'],
+                    'image'     => $_FILES['profile-picture'],
+                    'bio'       => 'This user has not added a bio yet.'
+                ]);
+        
+                //redirect to another page
+                header('Location: /login');
+                exit;
+            } else {
+                $_SESSION['invalid_registration'] = 'Username or email is already registered.';
+                header('Location: /register');
+                exit;
+            }
         }
     }
 

--- a/code/app/controllers/UserController.php
+++ b/code/app/controllers/UserController.php
@@ -54,7 +54,7 @@ class UserController {
             }
 
             $email = htmlspecialchars($_POST['email']);
-            $password = $_POST['password'];  //TODO: Hash passwords
+            $password = $_POST['password'];
             $user = $this->userModel->validateUserLogin($email, $password);
 
             if ($user) {

--- a/code/app/controllers/UserController.php
+++ b/code/app/controllers/UserController.php
@@ -53,7 +53,7 @@ class UserController {
                 header('Location: /login');
             }
 
-            $email = sanitizeData($_POST['email']);
+            $email = $_POST['email'];
             $password = $_POST['password'];
             $user = $this->userModel->validateUserLogin($email, $password);
 

--- a/code/app/controllers/UserController.php
+++ b/code/app/controllers/UserController.php
@@ -53,7 +53,7 @@ class UserController {
                 header('Location: /login');
             }
 
-            $email = htmlspecialchars($_POST['email']);
+            $email = sanitizeData($_POST['email']);
             $password = $_POST['password'];
             $user = $this->userModel->validateUserLogin($email, $password);
 

--- a/code/app/controllers/UserController.php
+++ b/code/app/controllers/UserController.php
@@ -61,7 +61,7 @@ class UserController {
                 // Store user session data
                 $_SESSION['username'] = $user['username'];
                 $_SESSION['email'] = $user['email'];
-                $_SESSION['profile_picture'] = $user['profile_picture'];
+                $_SESSION['profile-picture'] = $user['profile-picture'];
                 $_SESSION['role'] = $user['role'];
 
                 if ($_SESSION['role'] === 'admin') {

--- a/code/app/models/UserModel.php
+++ b/code/app/models/UserModel.php
@@ -26,6 +26,28 @@ class UserModel {
         return $result ?: null;
     }
     
+    /**
+     * Check if a user already exists with the username or email
+     * 
+     * @param string $username
+     * @param string $email
+     * @return bool true if the username or email exists, false otherwise
+     */
+    public function checkUserExists($username, $email): bool {
+        $statement = $this->db->prepare(<<<SQL
+            SELECT COUNT(*)
+            FROM users
+            WHERE username = ? OR email = ?
+        SQL);
+        $statement->execute([$username, $email]);
+        $result = $statement->fetchColumn();
+
+        if ($result > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Creates a user in the database.

--- a/code/app/views/login-view.php
+++ b/code/app/views/login-view.php
@@ -15,7 +15,7 @@
   <main>
     <div class="form-container">
       <div class="panel">
-        <form id="login-form" class="account-form" method="post" action="login" novalidate>
+        <form id="login-form" class="account-form" method="post" action="login" autocomplete="on" novalidate>
           <h1 class="form-title">Log in to your account</h1>
           <?php
             if (isset($_SESSION['invalid_login'])) {
@@ -25,8 +25,7 @@
           ?>
           <div class="form-group">
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" placeholder="Enter your email address" 
-            autocomplete="email" required />
+            <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="username" required />
           </div>
           <div class="form-group">
             <label for="password">Password</label>

--- a/code/app/views/register-view.php
+++ b/code/app/views/register-view.php
@@ -17,6 +17,12 @@
       <div class="panel">
         <form id="registration-form" class="account-form" method="post" enctype="multipart/form-data" autocomplete="on" novalidate>
           <h1 class="form-title">Register for an account</h1>
+          <?php
+            if (isset($_SESSION['invalid_registration'])) {
+              echo '<p class="invalid-login">' . $_SESSION['invalid_registration'] . '</p>';
+              unset($_SESSION['invalid_registration']);
+            }
+          ?>
           <div class="form-group">
             <label for="username">Username</label>
             <input type="text" id="username" name="username" placeholder="Enter your username" autocomplete="off" required />

--- a/code/app/views/register-view.php
+++ b/code/app/views/register-view.php
@@ -15,15 +15,15 @@
   <main>
     <div class="form-container">
       <div class="panel">
-        <form id="registration-form" class="account-form" method="post" enctype="multipart/form-data" novalidate>
+        <form id="registration-form" class="account-form" method="post" enctype="multipart/form-data" autocomplete="on" novalidate>
           <h1 class="form-title">Register for an account</h1>
           <div class="form-group">
             <label for="username">Username</label>
-            <input type="text" id="username" name="username" placeholder="Enter your username" required />
+            <input type="text" id="username" name="username" placeholder="Enter your username" autocomplete="off" required />
           </div>
           <div class="form-group">
             <label for="email">Email</label>
-            <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="email" required />
+            <input type="email" id="email" name="email" placeholder="Enter your email address" autocomplete="username" required />
           </div>
           <div class="form-group">
             <label for="password">Password</label>


### PR DESCRIPTION
- Client side, the registration and login forms now properly allow for autocompleting with email and password in the correct inputs.
- When users register, there is now a check if either a username or email already exists in the database, and rejects the registration/displays an error letting the user know.

>[!Note]
Both the registration and login forms are using a css class called `invalid-login` on the error messages when there are backend validation errors. I was running into a weird css issue and changing this name removes the styling. This is a minor thing but I can try fixing this later lol.