### PR TITLE
Full search page functionality

### DIFF
--- a/code/app/controllers/SearchController.php
+++ b/code/app/controllers/SearchController.php
@@ -1,22 +1,41 @@
 <?php
 
 require_once __DIR__.'/../models/PostModel.php';
+require_once __DIR__.'/../models/LikeModel.php';
+require_once __DIR__.'/../models/SaveModel.php';
 require_once __DIR__.'/../authentication/AuthService.php';
 
 class SearchController {
     private $postModel;
+    private $likeModel;
+    private $saveModel;
 
     public function __construct(PDO $db) {
         $this->postModel = new PostModel($db);
+        $this->likeModel = new LikeModel($db);
+        $this->saveModel = new SaveModel($db);
     }
 
     public function search() {
-        // TODO for milestone 4: search functionality
-
         $isLoggedIn = AuthService::isLoggedIn();
         $isAdmin = AuthService::isAdmin();
+        $showResults = false;
+        $postDataList = [];
 
-        // This view uses: $isLoggedIn, $isAdmin
+        if (isset($_GET['terms'])) {
+            $showResults = true;
+
+            $keywords = explode(' ', $_GET['terms']);
+            $postDataList = $this->postModel->getSearchedPosts($keywords);
+
+            foreach ($postDataList as &$postData) {
+                $postData['belongs_to_current_user'] = AuthService::isCurrentUser($postData['username']);
+                $postData = setLikeAndSaveStatus($postData, $isLoggedIn, $this->likeModel, $this->saveModel);
+            }
+            unset($postData);
+        }
+
+        // This view uses: $isLoggedIn, $isAdmin, $showResults, $postDataList
         require_once __DIR__."/../views/search-view.php";
     }
 }

--- a/code/app/controllers/SearchController.php
+++ b/code/app/controllers/SearchController.php
@@ -21,11 +21,13 @@ class SearchController {
         $isAdmin = AuthService::isAdmin();
         $showResults = false;
         $postDataList = [];
+        $searchValue = '';
 
         if (isset($_GET['terms'])) {
             $showResults = true;
+            $searchValue = $_GET['terms'];
 
-            $keywords = explode(' ', $_GET['terms']);
+            $keywords = explode(' ', $searchValue);
             $postDataList = $this->postModel->getSearchedPosts($keywords);
 
             foreach ($postDataList as &$postData) {
@@ -35,7 +37,7 @@ class SearchController {
             unset($postData);
         }
 
-        // This view uses: $isLoggedIn, $isAdmin, $showResults, $postDataList
+        // This view uses: $isLoggedIn, $isAdmin, $showResults, $postDataList, $searchValue
         require_once __DIR__."/../views/search-view.php";
     }
 }

--- a/code/app/models/PostModel.php
+++ b/code/app/models/PostModel.php
@@ -170,9 +170,13 @@ class PostModel {
         $valuesTwice = array_merge($values, $values); 
         $statement->execute($valuesTwice); 
 
-        // GET RESULT
-        $result = $statement->fetchAll(PDO::FETCH_ASSOC);
-        return $result;
+        // GET RESULTS
+        $results = $statement->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($results as &$result) {
+            $result['post_image'] = addImageMimeType($result['post_image']);
+        }
+        unset($result);
+        return $results;
     }
 
     public function createPost(array $postData) {

--- a/code/app/models/PostModel.php
+++ b/code/app/models/PostModel.php
@@ -144,7 +144,7 @@ class PostModel {
      * @param array $keywords Array of strings, any of which can match the title
      * @return array a list of posts with all the normal keys, ordered by number of matches first
      */
-    public function getSearchedPosts(array $keywords = ['weekend', 'hik']): array {
+    public function getSearchedPosts(array $keywords = []): array {
 
         // PREPARE SQL STATEMENT
         $matchCalculationParts = array_fill(0, count($keywords), 'IF(post_title LIKE ?, 1, 0)');

--- a/code/app/views/components/search-bar-component.php
+++ b/code/app/views/components/search-bar-component.php
@@ -3,6 +3,7 @@
  * search-bar-component.php
  * This component requires the following variables:
  * @var string $searchAction - a URL route for the search request to be sent to
+ * @var string $searchValue (optional) value to populate the searchbar with
  */
 ?>
 
@@ -10,11 +11,12 @@
 <form class="search-bar" action="<?= $searchAction ?>">
   <input
     type="search"
-    name="search"
-    placeholder="Search"
     title="Search posts by keyword"
+    name="terms"
+    placeholder="Search"
+    value="<?= $searchValue ?? '' ?>"
     required
-  />
+  >
   <button type="submit" class="button-icon-only">
     <svg class="icon-inline" preserveAspectRatio="xMidYMid meet">
       <use href="/../vector-icons/icons.svg#icon-search"></use>

--- a/code/app/views/components/search-bar-component.php
+++ b/code/app/views/components/search-bar-component.php
@@ -5,6 +5,9 @@
  * @var string $searchAction - a URL route for the search request to be sent to
  * @var string $searchValue (optional) value to populate the searchbar with
  */
+
+require_once __DIR__."/../../helpers/view-helpers.php";
+$searchValue = sanitizeData($searchValue ?? '');
 ?>
 
 <!-- Note: CSS for this is in main.css -->
@@ -14,7 +17,7 @@
     title="Search posts by keyword"
     name="terms"
     placeholder="Search"
-    value="<?= $searchValue ?? '' ?>"
+    value="<?= $searchValue ?>"
     required
   >
   <button type="submit" class="button-icon-only">

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -1,11 +1,19 @@
 <?php
-    require_once __DIR__."/../helpers/view-helpers.php";
+/**
+ * This view requires the following variables:
+ * @var bool $isAdmin
+ * @var bool $isLoggedIn
+ * @var bool $showResults
+ * @var array $postDataList
+ */
 
-    echo generateDocumentHead(
-        'Search',
-        ['search.css', 'post-list.css'],
-        ['post-interaction.js']
-    );
+require_once __DIR__."/../helpers/view-helpers.php";
+
+echo generateDocumentHead(
+    'Search',
+    ['search.css', 'post-list.css'],
+    ['post-interaction.js']
+);
 ?>
 
 <body>
@@ -14,7 +22,7 @@
   </header>
   <main>
     <header class="page-header">
-        <h1>Search</h1>
+        <h1>Search posts by keyword</h1>
     </header>
     <div class="panel">
       <section class="search">

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -22,15 +22,20 @@ echo generateDocumentHead(
   </header>
   <main>
     <header class="page-header">
-        <h1>Search posts by keyword</h1>
+        <h1>Search blog posts</h1>
     </header>
     <div class="panel">
       <?php
           $searchAction = '/search';
           // this component uses: $searchAction
           include __DIR__."/components/search-bar-component.php";
-      ?> 
+      ?>
+      <div class='help-message'>
+        You can search for blog posts using one or more keywords, seperated by spaces.
+        Press "Enter" or click the search icon to submit your query.
+      </div>
     </div>
+
   </main>
 </body>
 

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -25,14 +25,11 @@ echo generateDocumentHead(
         <h1>Search posts by keyword</h1>
     </header>
     <div class="panel">
-      <section class="search">
-        <?php
-            $searchAction = '/search';
-            // this component uses: $searchAction
-            include __DIR__."/components/search-bar-component.php";
-        ?>
-      </section>
-      <p>Note: full search functionality is coming in milestone 4</p>
+      <?php
+          $searchAction = '/search';
+          // this component uses: $searchAction
+          include __DIR__."/components/search-bar-component.php";
+      ?> 
     </div>
   </main>
 </body>

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -5,6 +5,7 @@
  * @var bool $isLoggedIn
  * @var bool $showResults
  * @var array $postDataList
+ * @var string $searchValue
  */
 
 require_once __DIR__."/../helpers/view-helpers.php";
@@ -27,21 +28,23 @@ echo generateDocumentHead(
     <header class="page-header">
         <h1>Search blog posts</h1>
     </header>
+
     <div class="panel post-list">
       <?php
           $searchAction = '/search';
-          // this component uses: $searchAction
+          // this component uses: $searchAction, $searchValue
           include __DIR__."/components/search-bar-component.php";
       ?>
+
       <?php if (! $showResults): ?>
         <div class='search-message help-message'>
-            You can search for blog posts using one or more keywords, seperated by spaces.
+            You can search for blog post titles using one or more keywords, seperated by spaces.
             Press "Enter" or click the search icon to submit your query.
         </div>
       <?php else: ?>
         <h3 class='search-message'>
           <?= empty($postDataList) ? ':( No' :  'Showing' ?>
-          results for: TODO insert terms var
+          results for "<?= $searchValue ?>"
         </h3>
         <?php
             foreach ($postDataList as $postData) {

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -42,15 +42,20 @@ echo generateDocumentHead(
             Press "Enter" or click the search icon to submit your query.
         </div>
       <?php else: ?>
-        <h3 class='search-message'>
-          <?= empty($postDataList) ? ':( No' :  'Showing' ?>
-          results for "<?= $searchValue ?>"
-        </h3>
+        <div class='search-message result-message'>
+          <h3>
+            <?= empty($postDataList) ? ':( No' :  'Showing' ?>
+            results for "<?= $searchValue ?>"
+          </h3>
+          <a class='clear-link' href='/search'>
+            Clear
+          </a>
+        </div>
         <?php
-            foreach ($postDataList as $postData) {
-                // This component uses: $postData
-                include __DIR__."/components/post-summary-component.php";
-            }
+          foreach ($postDataList as $postData) {
+            // This component uses: $postData
+            include __DIR__."/components/post-summary-component.php";
+          }
         ?>
       <?php endif; ?>
     </div>

--- a/code/app/views/search-view.php
+++ b/code/app/views/search-view.php
@@ -18,22 +18,38 @@ echo generateDocumentHead(
 
 <body>
   <header>
-    <?php require_once __DIR__."/components/side-nav-component.php" ?>
+    <?php
+        //this component uses: $isAdmin, $isLoggedIn
+        require_once __DIR__."/components/side-nav-component.php"
+    ?>
   </header>
   <main>
     <header class="page-header">
         <h1>Search blog posts</h1>
     </header>
-    <div class="panel">
+    <div class="panel post-list">
       <?php
           $searchAction = '/search';
           // this component uses: $searchAction
           include __DIR__."/components/search-bar-component.php";
       ?>
-      <div class='help-message'>
-        You can search for blog posts using one or more keywords, seperated by spaces.
-        Press "Enter" or click the search icon to submit your query.
-      </div>
+      <?php if (! $showResults): ?>
+        <div class='search-message help-message'>
+            You can search for blog posts using one or more keywords, seperated by spaces.
+            Press "Enter" or click the search icon to submit your query.
+        </div>
+      <?php else: ?>
+        <h3 class='search-message'>
+          <?= empty($postDataList) ? ':( No' :  'Showing' ?>
+          results for: TODO insert terms var
+        </h3>
+        <?php
+            foreach ($postDataList as $postData) {
+                // This component uses: $postData
+                include __DIR__."/components/post-summary-component.php";
+            }
+        ?>
+      <?php endif; ?>
     </div>
 
   </main>

--- a/code/public/css/main.css
+++ b/code/public/css/main.css
@@ -115,7 +115,7 @@ main {
 }
 
 .page-header {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
 }
 
 .breadcrumbs a {

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -1,5 +1,19 @@
+/*
+NOTE: this file is for the search-PAGE specific styles.
+Search BAR styes are in main.css
+*/
+
 .search-results {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+}
+
+.search-bar-container {
+    padding: 1.5rem;
+    padding-top: 0;
+}
+
+.search-bar {
+    background-color: var(--background-primary);
 }

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -3,12 +3,6 @@ NOTE: this file is for the search-PAGE specific styles.
 Search BAR styes are in main.css
 */
 
-.search-results {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
 .search-bar {
     background-color: var(--background-primary);
 }

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -14,6 +14,9 @@ Search BAR styes are in main.css
 }
 
 .help-message {
-    margin-top: 1.5em;
     font-style: italic;
+}
+
+.search-message {
+    margin-top: 1.5em;
 }

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -9,11 +9,11 @@ Search BAR styes are in main.css
     gap: 1rem;
 }
 
-.search-bar-container {
-    padding: 1.5rem;
-    padding-top: 0;
-}
-
 .search-bar {
     background-color: var(--background-primary);
+}
+
+.help-message {
+    margin-top: 1.5em;
+    font-style: italic;
 }

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -1,7 +1,3 @@
-.search {
-    margin-bottom: 1rem;
-}
-
 .search-results {
     display: flex;
     flex-direction: column;

--- a/code/public/css/search.css
+++ b/code/public/css/search.css
@@ -13,4 +13,14 @@ Search BAR styes are in main.css
 
 .search-message {
     margin-top: 1.5em;
+    display: flex;
+    justify-content:space-between;
+}
+
+.clear-link {
+    text-decoration: none;
+}
+.clear-link:hover {
+    font-weight: bold;
+    text-decoration:underline;
 }


### PR DESCRIPTION
# 🔍 Search is functional! 🔎 
- Closes #168. 

## Search stuff
This branch makes the search page (and the search bar on home) functional. You can search for posts by title using one or more keywords, separated by spaces. The results are ordered by number of matching keywords (to see this working, try searching `"in the"`).

Note that keywords are not necessarily actual "words". For example, the query `"w h"` would match with any of the following post titles:
1. `Hello World`
2. `wh`
3. `w h`
4. `w`
5. `h`

The first three titles all contain both "keywords", so they each have 2 "matches" and will be shown first in the results. Even though title (3) is an exact match, there is no guarantee it will be shown before titles 1 and 2.

The search mechanism is very basic; it just looks for exact pattern matches. See `PostModel::getSearchedPosts()` for more details on how it works.

## Search-adjacent stuff
- help message shows when no query has been made
- 'no results' message shows if there are no matches
- there is a link to "clear" or reset the search page (since refreshing the page will keep the query string and therefore not change anything)

## Other stuff
- I made the universal `page-header` margin slightly bigger, to make things feel less tight.