### PR TITLE
Site Name + Fonts

### DIFF
--- a/code/app/helpers/view-helpers.php
+++ b/code/app/helpers/view-helpers.php
@@ -115,7 +115,7 @@ function generateDocumentHead(string $title, array $extraStylesheets, array $ext
           <meta name="viewport" content="width=device-width, initial-scale=1" />
 
           <title>
-            $title | Our Site
+            $title | BlogStar
           </title>
 
           <link rel="icon" type="image/svg+xml" href="$faviconUrl">

--- a/code/app/views/about-view.php
+++ b/code/app/views/about-view.php
@@ -38,7 +38,7 @@
         </ul>
         <h3>Code</h3>
         <p>
-          You can find the source code for this website at <a href="https://github.com/iansteyn/cosc-360-project" target="_blank">our GitHub repository</a>. We used no front-end frameworks. It's pure HTML/CSS/JS, hand-crafted!
+          You can find the source code for this website at <a href="https://github.com/iansteyn/cosc-360-project" target="_blank">our GitHub repository</a>. We used no front-end frameworks. It's pure HTML/CSS/JS, hand-crafted! The back-end stack is LAMP (Linux, Apache, MySQL, PHP), again without any frameworks.
         </p>
         <h3>Attribution</h3>
         <p>

--- a/code/app/views/about-view.php
+++ b/code/app/views/about-view.php
@@ -16,10 +16,10 @@
         <h2>
           Welcome to
           <?= generateIconInline('icon-logo') ?>
-          <span class='logo-text'>Our Site</span>!
+          <span class='logo-text'>BlogStar</span>!
         </h2>
         <p>
-          Our site is a personal blogging website, where you can create and read longform text posts. There's lots of different ways to find posts: search by keyword, check out what's popular, and save your favorites! You can also engage with other bloggers by browsing their profiles and commenting on their posts.
+          BlogStar is a personal blogging website, where you can create and read longform text posts. There's lots of different ways to find posts: search by keyword, check out what's popular, and save your favorites! You can also engage with other bloggers by browsing their profiles and commenting on their posts.
         </p>
         <p>
           This site was created as a term project for COSC 360 - Web Programming. We have learned a great deal in the process, and are very proud of what we have built.

--- a/code/app/views/about-view.php
+++ b/code/app/views/about-view.php
@@ -63,10 +63,11 @@
             <?= generateIconInline('icon-delete') ?>
             <i>delete</i>
             buttons on your profile page or on the post itself.
+            You can also delete your comments.
           </p>
         </details>
         <details>
-          <summary><h3>How do I change my username/password/profile picture?</h3></summary>
+          <summary><h3>How do I change my bio/password/profile picture?</h3></summary>
           <p>
             See the <a href="<?= routeUrl('/profile/settings') ?>">settings tab</a> on your profile page.
           </p>

--- a/code/app/views/about-view.php
+++ b/code/app/views/about-view.php
@@ -16,7 +16,7 @@
         <h2>
           Welcome to
           <?= generateIconInline('icon-logo') ?>
-          Our Site!
+          <span class='logo-text'>Our Site</span>!
         </h2>
         <p>
           Our site is a personal blogging website, where you can create and read longform text posts. There's lots of different ways to find posts: search by keyword, check out what's popular, and save your favorites! You can also engage with other bloggers by browsing their profiles and commenting on their posts.

--- a/code/app/views/components/side-nav-component.php
+++ b/code/app/views/components/side-nav-component.php
@@ -15,7 +15,7 @@ require_once __DIR__."/../../helpers/view-helpers.php";
         <use href="<?= resourceUrl('vector-icons/icons.svg#icon-logo') ?>"></use>
       </svg>
       <span class="nav-link-text logo-text">
-        OUR SITE
+        BlogStar
       </span>
     </a>
   </div>

--- a/code/public_html/css/main.css
+++ b/code/public_html/css/main.css
@@ -67,9 +67,8 @@ body{
 
 h1, h2, h3, h4, h5, h6 {
     font-weight: bold;
-    /* font-family: 'Cambria', Georgia, Times, 'Times New Roman', serif; */
+    font-family: 'Cambria', Georgia, Times, 'Times New Roman', serif;
 }
-
 
 
 h1{font-size: 2em;}

--- a/code/public_html/css/main.css
+++ b/code/public_html/css/main.css
@@ -65,11 +65,14 @@ body{
   color: var(--text-primary);
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1, h2, h3, h4, h5, h6, span.logo-text {
     font-weight: bold;
     font-family: 'Cambria', Georgia, Times, 'Times New Roman', serif;
 }
 
+span.logo-text {
+    font-style: italic;
+}
 
 h1{font-size: 2em;}
 h2{font-size: 1.5em;}

--- a/code/public_html/css/main.css
+++ b/code/public_html/css/main.css
@@ -61,13 +61,16 @@ This is where we put styles that are shared by all (or most) pages.
 
 /* TEXT STUFF */
 body{
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Roboto', Arial, Helvetica, sans-serif;
   color: var(--text-primary);
 }
 
 h1, h2, h3, h4, h5, h6 {
     font-weight: bold;
+    /* font-family: 'Cambria', Georgia, Times, 'Times New Roman', serif; */
 }
+
+
 
 h1{font-size: 2em;}
 h2{font-size: 1.5em;}

--- a/code/public_html/css/main.css
+++ b/code/public_html/css/main.css
@@ -61,8 +61,8 @@ This is where we put styles that are shared by all (or most) pages.
 
 /* TEXT STUFF */
 body{
-  font-family: 'Roboto', Arial, Helvetica, sans-serif;
-  color: var(--text-primary);
+    font-family: 'Roboto', Arial, Helvetica, sans-serif;
+    color: var(--text-primary);
 }
 
 h1, h2, h3, h4, h5, h6, span.logo-text {
@@ -84,6 +84,7 @@ h6{font-size: 0.67em;}
 p{
     font-size: 1em;
     margin: 1em 0;
+    line-height: 1.4;
 }
 
 i { font-style: italic; }

--- a/code/public_html/css/main.css
+++ b/code/public_html/css/main.css
@@ -85,6 +85,7 @@ p{
     font-size: 1em;
     margin: 1em 0;
     line-height: 1.4;
+    hyphens: auto;
 }
 
 i { font-style: italic; }

--- a/code/public_html/css/post-list.css
+++ b/code/public_html/css/post-list.css
@@ -45,6 +45,7 @@
 }
 .blog-start {
     margin: 1em 0 0;
+    line-height: 1.2;
 }
 .post-summary-title a, .blog-start a {
     color: var(--text-primary);

--- a/code/public_html/css/side-nav.css
+++ b/code/public_html/css/side-nav.css
@@ -47,7 +47,7 @@ Styles for the side navigation bar.
 }
 .logo-text.nav-link-text {
     margin: 0;
-    font-size:1.5em;
+    font-size:1.4em;
     font-style: italic;
 }
 

--- a/code/public_html/css/side-nav.css
+++ b/code/public_html/css/side-nav.css
@@ -47,6 +47,8 @@ Styles for the side navigation bar.
 }
 .logo-text.nav-link-text {
     margin: 0;
+    font-size:1.5em;
+    font-style: italic;
 }
 
 /* LINKS */

--- a/code/public_html/css/side-nav.css
+++ b/code/public_html/css/side-nav.css
@@ -43,7 +43,7 @@ Styles for the side navigation bar.
     display: block;
     width: 4em;
     height: 4em;
-    margin: 1em auto 0.75em;
+    margin: 1em auto 1em;
 }
 .logo-text.nav-link-text {
     margin: 0;


### PR DESCRIPTION
# Let's settle this.
- closes #173, closes #90 

This branch adds some new fonts, and renames the site. I have requested both of you for review, since we should decide on the final stylistic look of the site as a team. Feel free to play around with it if you want.

Specifics:
## Fonts
- `Roboto` for body text. Nothing distracting, but it looks just a little less default than Arial (which is a good font in its own right, don't get me wrong). In particular, notice the much nicer username links.
- `Cambria` for headings. I like the slightly more sophisticated look of a serif font for headings (these are blogs, not tweets), but you could easily get too sharp and elegant for the cute design of our site. I think Cambria strikes a very good balance of keeping the look friendly and clean, while giving it an extra something.
  - However, if you guys don't like the idea of a serif font, I would suggest also using Roboto for headings.

## Site name
"BlogStar" is nothing special, but it physically fits into the nav well, and I've become endeared to the little placeholder star logo.

## Paragraph improvements
- increased line height for paragraph text to make it feel less cramped, but kept it slightly more compressed for post summaries
- added css `hyphens: auto` property, which uses browser rules to break words over lines at correct-feeling places. This reduces the raggedness of the right edge of text, especially for the user bio. Unfortunately it does not solve #169. 