### PR TITLE
Extend interval for popular posts to 1 month

### DIFF
--- a/code/app/models/PostModel.php
+++ b/code/app/models/PostModel.php
@@ -81,7 +81,7 @@ class PostModel {
                 JOIN likes
                 ON posts.post_id = likes.post_id
             WHERE
-                post_date >= DATE_SUB(CURDATE(), INTERVAL 1 WEEK)
+                post_date >= DATE_SUB(CURDATE(), INTERVAL 1 MONTH)
             GROUP BY
                 posts.post_id
             ORDER BY


### PR DESCRIPTION
Very simple fix. Just ensures that the tab will actually have something in it when TAs are grading.
- closes #189.