### PR TITLE
File size fix

### DIFF
--- a/code/app/views/create-edit-view.php
+++ b/code/app/views/create-edit-view.php
@@ -31,7 +31,7 @@
     echo generateDocumentHead(
         $pageTitle,
         ['forms.css', 'create-edit.css'],
-        ['create-edit.js']
+        ['create-edit.js', 'image-size-limit.js']
     );
 ?>
 

--- a/code/app/views/profile-view.php
+++ b/code/app/views/profile-view.php
@@ -14,7 +14,7 @@ $userData = sanitizeData($userData);
 echo generateDocumentHead(
     'My Profile',
     ['forms.css', 'tabs.css', 'post-list.css', 'user-bio.css'],
-    ['post-interaction.js', 'form-validation.js']
+    ['post-interaction.js', 'form-validation.js', 'image-size-limit.js']
 );
 ?>
 

--- a/code/public_html/scripts/image-size-limit.js
+++ b/code/public_html/scripts/image-size-limit.js
@@ -6,8 +6,8 @@ since this is the max_allowed_packet for the remote server.
 */
 const MAX_FILE_SIZE = 2 * 1000 * 1000; // 2MB
 
-const forms = Array.from(document.querySelectorAll('form'));
-const formWithFileInput = forms.filter(form => form.querySelector('input[type="file"]'))[0]; //there should only be one per page in the current site implementation
+const allForms = Array.from(document.querySelectorAll('form'));
+const formWithFileInput = allForms.filter(form => form.querySelector('input[type="file"]'))[0]; //there should only be one per page in the current site implementation
 const fileInput = formWithFileInput.querySelector('input[type="file"]');
 
 formWithFileInput.addEventListener ('submit', (submitEvent)=> {
@@ -33,6 +33,7 @@ function displayError(input, message) {
     input.classList.add("validation-error");
 }
 
+// (modified from form-validation.js)
 function removeError(input) {
     const errors = input.parentElement.querySelectorAll(".error-message");
     errors.forEach((error) => error.remove());

--- a/code/public_html/scripts/image-size-limit.js
+++ b/code/public_html/scripts/image-size-limit.js
@@ -1,0 +1,11 @@
+/* image-size-limit.js
+-----------------------
+This is a last-minute addition
+It simply ensures that uploaded images cannot be more than 2 MB,
+since this is the max_allowed_packet for the remote server.
+*/
+
+form = document.querySelector('form::has(input[type="file"])');
+
+console.log(form);
+

--- a/code/public_html/scripts/image-size-limit.js
+++ b/code/public_html/scripts/image-size-limit.js
@@ -4,7 +4,7 @@ This is a last-minute addition
 It simply ensures that uploaded images cannot be more than 2 MB,
 since this is the max_allowed_packet for the remote server.
 */
-const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+const MAX_FILE_SIZE = 2 * 1000 * 1000; // 2MB
 
 const forms = Array.from(document.querySelectorAll('form'));
 const formWithFileInput = forms.filter(form => form.querySelector('input[type="file"]'))[0]; //there should only be one per page in the current site implementation

--- a/code/public_html/scripts/image-size-limit.js
+++ b/code/public_html/scripts/image-size-limit.js
@@ -34,10 +34,8 @@ function displayError(input, message) {
 }
 
 function removeError(input) {
-    const error = input.parentElement.querySelector(".error-message");
-    if (error) {
-        error.remove();
-        input.classList.remove("validation-error");
-    }
+    const errors = input.parentElement.querySelectorAll(".error-message");
+    errors.forEach((error) => error.remove());
+    input.classList.remove("validation-error");
 }
 

--- a/code/public_html/scripts/image-size-limit.js
+++ b/code/public_html/scripts/image-size-limit.js
@@ -4,8 +4,40 @@ This is a last-minute addition
 It simply ensures that uploaded images cannot be more than 2 MB,
 since this is the max_allowed_packet for the remote server.
 */
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 
-form = document.querySelector('form::has(input[type="file"])');
+const forms = Array.from(document.querySelectorAll('form'));
+const formWithFileInput = forms.filter(form => form.querySelector('input[type="file"]'))[0]; //there should only be one per page in the current site implementation
+const fileInput = formWithFileInput.querySelector('input[type="file"]');
 
-console.log(form);
+formWithFileInput.addEventListener ('submit', (submitEvent)=> {
+    if (fileInput.files[0].size > MAX_FILE_SIZE) {
+        submitEvent.preventDefault();
+        displayError(fileInput, "File must be less than 2MB.");
+    }
+});
+
+fileInput.addEventListener('input', (inputEvent)=> {
+    removeError(fileInput);
+});
+
+// HELPERS
+// (copied from form-validation.js)
+function displayError(input, message) {
+    const div = document.createElement("div");
+    div.textContent = message;
+    div.className = "error-message";
+    div.style.color = "var(--color-error)";
+    div.style.maxWidth = "42ch";
+    input.parentElement.appendChild(div);
+    input.classList.add("validation-error");
+}
+
+function removeError(input) {
+    const error = input.parentElement.querySelector(".error-message");
+    if (error) {
+        error.remove();
+        input.classList.remove("validation-error");
+    }
+}
 

--- a/code/public_html/scripts/side-nav.js
+++ b/code/public_html/scripts/side-nav.js
@@ -34,7 +34,6 @@ if (['/home/recent', '/home/popular', '/home/saved'].includes(currentPagePath)) 
 }
 else if (['/profile/posts', '/profile/saved', '/profile/settings'].includes(currentPagePath)) {
     const profileLink = document.querySelector(`.nav-link[href='${BASE_URL}?route=/profile']`);
-    console.log(profileLink);
     profileLink.classList.add("current-page");
 }
 else if ('/post/create' == currentPagePath) {


### PR DESCRIPTION
- closes #195.
 
## The fix
This is a hacky, bad practices fix, but it's a fix. Images over 2 MB can now not be uploaded on create, edit, or settings.

I just made a new JS file instead of messing with `form-validation.js`. It basically just prevents form submission and displays an error message if a submitted file is > 2 MB. 

##  What is a megabyte?
Also, I think the real reason Sammie was so confused yesterday, and still getting packet size errors, was the problem of what a MB actually is. This has annoyed me for years. Many of us learn that it is 1024 kilobytes, which are themselves 1024 bytes each.  But _actually_ a kilobyte is 1000 bytes, and a megabyte is 1000 kilobytes.

Except at one point, megabyte _did_ mean 1024 kilobytes, but the meaning gradually shifted. The current IEC standard says that a megabyte (MB) is 1000 kilobytes, and that a _mebibyte_ (MiB) is 1024 _kibibytes_ (KiB). _However..._ in the specific context of directly addressable computer memory, "megabyte", "kilobyte" etc still refer to multiples of 1024. As a result, MiB, KiB etc have had trouble catching on and all of society will be confused about this forever.

**TL;DR** the max size needed to be `2 * 1000 * 1000` rather than `2 * 1024 * 1024`  to correctly match the MySQL `2M` limit.

---

Further reading: [Multiple byte units - Wikipedia](https://en.wikipedia.org/wiki/Byte#Multiple-byte_units)